### PR TITLE
Common OIDCWebFlowHandler for CLIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/gorilla/mux v1.8.0
 	github.com/jlewi/p22h/backend v0.0.0-20220627190823-9107137fbd82
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.0
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -484,6 +484,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -803,6 +805,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/networking/ports.go
+++ b/networking/ports.go
@@ -1,0 +1,19 @@
+package networking
+
+import (
+	"net"
+)
+
+func GetFreePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}

--- a/oauthutil/oidc_webflow.go
+++ b/oauthutil/oidc_webflow.go
@@ -1,0 +1,183 @@
+package oauthutil
+
+import (
+	"fmt"
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-logr/logr"
+	"github.com/gorilla/mux"
+	"github.com/jlewi/p22h/backend/api"
+	"github.com/jlewi/p22h/backend/pkg/debug"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// OIDCWebFlowServer creates a server to be used to go through the web flow to get a token source
+// for use in a CLI.
+//
+// It is based on the code in https://github.com/coreos/go-oidc/blob/v3/example/idtoken/app.go.
+//
+// N.B: https://github.com/coreos/go-oidc/issues/354 is discussing creating a reusable server.
+//
+// TODO(jeremy): Add caching of the refresh token.
+type OIDCWebFlowServer struct {
+	log      logr.Logger
+	config   oauth2.Config
+	verifier *oidc.IDTokenVerifier
+	host     string
+	c        chan tokenSourceOrError
+	srv      *http.Server
+}
+
+func NewOIDCWebFlowServer(config oauth2.Config, verifier *oidc.IDTokenVerifier, log logr.Logger) (*OIDCWebFlowServer, error) {
+	u, err := url.Parse(config.RedirectURL)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Could not parse URL %v", config.RedirectURL)
+	}
+
+	return &OIDCWebFlowServer{
+		log:      log,
+		config:   config,
+		verifier: verifier,
+		host:     u.Host,
+		c:        make(chan tokenSourceOrError, 10),
+	}, nil
+}
+
+func (s *OIDCWebFlowServer) Address() string {
+	return fmt.Sprintf("http://%v", s.host)
+}
+
+// AuthStartURL returns the URL to kickoff the oauth login flow.
+func (s *OIDCWebFlowServer) AuthStartURL() string {
+	return s.Address() + authStartPrefix
+}
+
+func (s *OIDCWebFlowServer) writeStatus(w http.ResponseWriter, message string, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+
+	resp := api.RequestStatus{
+		Kind:    "RequestStatus",
+		Message: message,
+		Code:    code,
+	}
+
+	enc := json.NewEncoder(w)
+	if err := enc.Encode(resp); err != nil {
+		s.log.Error(err, "Failed to marshal RequestStatus", "RequestStatus", resp, "code", code)
+	}
+
+	if code != http.StatusOK {
+		caller := debug.ThisCaller()
+		s.log.Info("HTTP error", "RequestStatus", resp, "code", code, "caller", caller)
+	}
+}
+
+func (s *OIDCWebFlowServer) HealthCheck(w http.ResponseWriter, r *http.Request) {
+	s.writeStatus(w, "OIDC server is running", http.StatusOK)
+}
+
+func (s *OIDCWebFlowServer) NotFoundHandler(w http.ResponseWriter, r *http.Request) {
+	s.writeStatus(w, fmt.Sprintf("OIDC server doesn't handle the path; url: %v", r.URL), http.StatusNotFound)
+}
+
+// waitForReady waits until the server is health.
+func (s *OIDCWebFlowServer) waitForReady() error {
+	endTime := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(endTime) {
+
+		r, err := http.Get(s.Address() + "/healthz")
+		if err == nil && r.StatusCode == http.StatusOK {
+			return nil
+		}
+		time.Sleep(5 * time.Second)
+	}
+	return errors.New("timeout waiting for server to be healthy")
+}
+
+// Run runs the flow to create a tokensource.
+func (s *OIDCWebFlowServer) Run() (oauth2.TokenSource, error) {
+	log := s.log
+
+	go func() {
+		s.startAndBlock()
+	}()
+	log.Info("Waiting for OIDC server to be ready")
+	if err := s.waitForReady(); err != nil {
+		return nil, err
+	}
+	authURL := s.AuthStartURL()
+	log.Info("Opening URL to start Auth Flow", "URL", authURL)
+	if err := browser.OpenURL(authURL); err != nil {
+		log.Error(err, "Failed to open URL in browser; open it manually", "url", authURL)
+		fmt.Printf("Go to the following link in your browser to complete  the OIDC flow: %v\n", authURL)
+	}
+	// Wait for the token source
+	log.Info("Waiting for OIDC login flow to complete")
+
+	defer func() {
+		log.Info("Shutting OIDC server down")
+		err := s.srv.Shutdown(context.Background())
+		if err != nil {
+			log.Error(err, "There was a problem shutting the OIDC server down")
+		}
+	}()
+	select {
+	case tsOrError := <-s.c:
+		if tsOrError.err != nil {
+			return nil, errors.Wrapf(tsOrError.err, "OIDC flow didn't complete successfully")
+		}
+		log.Info("OIDC flow completed")
+		return tsOrError.ts, nil
+	case <-time.After(3 * time.Minute):
+		return nil, errors.New("Timeout waiting for OIDC flow to complete")
+	}
+}
+
+// startAndBlock starts the server and blocks.
+func (s *OIDCWebFlowServer) startAndBlock() {
+	log := s.log
+
+	router := mux.NewRouter().StrictSlash(true)
+
+	router.HandleFunc(authStartPrefix, s.handleStartWebFlow)
+	router.HandleFunc("/healthz", s.HealthCheck)
+	router.HandleFunc(authCallbackUrl, s.handleAuthCallback)
+
+	router.NotFoundHandler = http.HandlerFunc(s.NotFoundHandler)
+
+	log.Info("OIDC server is running", "address", s.Address())
+
+	s.srv = &http.Server{Addr: s.host, Handler: router}
+
+	err := s.srv.ListenAndServe()
+
+	if err != nil {
+		log.Error(err, "OIDCWebFlowServer returned error")
+	}
+	log.Info("OIDC server has been shutdown")
+}
+
+func (p *Proxy) addRoutes() error {
+	router := mux.NewRouter().StrictSlash(true)
+	p.router = router
+
+	router.HandleFunc(healthPath, p.healthCheck)
+
+	p.log.Info("Adding OIDC login handlers")
+	router.HandleFunc(oauthStart, p.handleOAuthStart)
+	u, err := url.Parse(p.handlers.Config().RedirectURL)
+	if err != nil {
+		return errors.Wrapf(err, "Could not parse URL %v", p.handlers.Config().RedirectURL)
+	}
+	router.HandleFunc(u.Path, p.handleOAuthCallback)
+	router.HandleFunc(idTokenPath, p.oidcEnsureAuth(p.handleToken))
+
+	router.NotFoundHandler = p.oidcEnsureAuth(p.proxyRequest)
+
+	// TODO(jeremy): Can we verify that interceptors for Auth are on each page.
+	return nil
+}

--- a/oauthutil/oidc_webflow_int_test.go
+++ b/oauthutil/oidc_webflow_int_test.go
@@ -1,0 +1,38 @@
+//go:build integration
+
+package oauthutil
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_NewWebFlowFromFlags(t *testing.T) {
+	// Integration test useful for development/debugging
+	f := OIDCWebFlowFlags{
+		Issuer:          "https://accounts.google.com",
+		OAuthClientFile: "/Users/jlewi/secrets/roboweb-lewi-iap-oauth-client.json",
+	}
+
+	flow, err := f.Flow()
+	if err != nil {
+		t.Fatalf("Failed to create flow; %v", err)
+	}
+
+	ts, err := flow.Run()
+
+	if err != nil {
+		t.Fatalf("Failed to run flow; %v", err)
+	}
+
+	idTs, ok := ts.(*IDTokenSource)
+	if !ok {
+		t.Fatalf("Expected IDTokenSource got %T", ts)
+	}
+
+	idToken, err := idTs.IDToken()
+	if err != nil {
+		t.Fatalf("Failed to get id token; %v", err)
+	}
+	fmt.Printf("ID Token: %v", idToken)
+}


### PR DESCRIPTION
Create a helper library to go through the OIDC flow in CLIs.

TODO(jeremy): Add the ability to cache refresh tokens.

Fix #2 