### PR TITLE
iap set-policy supports K8s Gateway resource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,18 @@ echo:
 build-dir:
 	mkdir -p .build
 
-build-go: build-dir
+build: build-dir
 	CGO_ENABLED=0 go build -o .build/devcli github.com/jlewi/monogo/cli
 
-tidy-go:
+tidy:
 	gofmt -s -w .
 	goimports -w .
 
-lint-go:
+lint:
 	# golangci-lint automatically searches up the root tree for configuration files.
 	golangci-lint run
 
-test-go:
+test:
 	go test -v ./...
 
 test-go-integration:

--- a/api/v1alpha1/iap.go
+++ b/api/v1alpha1/iap.go
@@ -23,8 +23,11 @@ type ResourceRef struct {
 }
 
 type ServiceRef struct {
-	Project   string `yaml:"project" json:"project"`
-	Service   string `yaml:"service" json:"service"`
+	Project string `yaml:"project" json:"project"`
+	Service string `yaml:"service" json:"service"`
+	// Ingress isn't needed if you are using a gateway
+	// TODO(jeremy): Can we deprecate specifying ingress and instead get the neg name from the K8s service annotation
+	// always i.e always use resolver.GetGCPBackendFromService
 	Ingress   string `yaml:"ingress" json:"ingress"`
 	Namespace string `yaml:"namespace" json:"namespace"`
 }

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
 	k8s.io/kubectl v0.26.1
+	sigs.k8s.io/gateway-api v0.6.2
 )
 
 require (
@@ -60,7 +61,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/imdario/mergo v0.3.6 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -374,8 +374,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/imdario/mergo v0.3.6 h1:xTNEAn+kxVO7dTZGu0CegyqKZmoWFI0rF8UxjlB2d28=
-github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
+github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
@@ -1107,6 +1107,7 @@ gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -1152,6 +1153,8 @@ k8s.io/utils v0.0.0-20221107191617-1a15be271d1d/go.mod h1:OLgZIPagt7ERELqWJFomSt
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/gateway-api v0.6.2 h1:583XHiX2M2bKEA0SAdkoxL1nY73W1+/M+IAm8LJvbEA=
+sigs.k8s.io/gateway-api v0.6.2/go.mod h1:EYJT+jlPWTeNskjV0JTki/03WX1cyAnBhwBJfYHpV/0=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kustomize/api v0.12.1 h1:7YM7gW3kYBwtKvoY216ZzY+8hM+lV53LUayghNRJ0vM=

--- a/iap/resolve_test.go
+++ b/iap/resolve_test.go
@@ -1,8 +1,16 @@
 package iap
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/jlewi/monogo/k8s"
+	"k8s.io/client-go/util/homedir"
+
+	compute "cloud.google.com/go/compute/apiv1"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -50,5 +58,42 @@ func Test_GetGCPBackendFromIngress(t *testing.T) {
 				t.Errorf("Got %v; want %v", actual, c.Expected)
 			}
 		})
+	}
+}
+
+func Test_GatewayToBackend(t *testing.T) {
+	// This is an "integration" test that requires access to GCP
+	// It is useful for development. The actual values would have to be updated
+	// based on the project and service used for testing.
+	if os.Getenv("GITHUB_ACTIONS") != "" {
+		t.Skip("Skipping test in GitHub Actions")
+	}
+	bSvc, err := compute.NewBackendServicesRESTClient(context.Background())
+	defer bSvc.Close()
+
+	if err != nil {
+		t.Fatalf("Failed to create backend service client: %v", err)
+	}
+
+	k8sFlags := &k8s.K8SClientFlags{
+		Kubeconfig: filepath.Join(homedir.HomeDir(), ".kube", "config"),
+	}
+	k8sClient, err := k8sFlags.NewClient()
+
+	if err != nil {
+		t.Fatalf("Failed to create k8s client: %v", err)
+	}
+
+	negToBackend, err := GetGCPBackendFromService(k8sClient, bSvc, "chat-lewi", "gateway", "site-v1")
+	if err != nil {
+		t.Fatalf("Failed to get backend: %v", err)
+	}
+
+	expected := map[string]string{
+		"k8s1-ec8d20c1-gateway-site-v1-8080-c416a331": "gkegw1-u3ex-gateway-site-v1-8080-r546wxld07pe",
+	}
+
+	if d := cmp.Diff(expected, negToBackend); d != "" {
+		t.Errorf("Got unexpected diff: %v", d)
 	}
 }

--- a/iap/resolver.go
+++ b/iap/resolver.go
@@ -4,9 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
+	compute "cloud.google.com/go/compute/apiv1"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"google.golang.org/api/iterator"
+
+	computepb "cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +22,7 @@ import (
 
 const (
 	backendsAnnotation = "ingress.kubernetes.io/backends"
+	negAnnotation      = "cloud.google.com/neg-status"
 )
 
 // GetGCPBackend determines the GCP backend associated with the given K8s service.
@@ -29,11 +37,95 @@ func GetGCPBackend(client *kubernetes.Clientset, namespace string, serviceName s
 	return GetGCPBackendFromIngress(ingress, namespace, serviceName)
 }
 
+type NegStatus struct {
+	NetworkEndpointGroups map[string]string `json:"network_endpoint_groups"`
+	Zones                 []string          `json:"zones"`
+}
+
+// GetGCPBackendFromService determines the GCP backend associated with the given K8s service.
+// It fetches the Neg associated with the given K8s service from its annotations.
+// It then loops over backendservices to find the backend associated with that neg.
+//
+// Returns a mapping from neg name to backend service name.
+//
+// There can be more than 1 neg associated with a backend service; because negs are port specific
+// N.B. This was tested with the Gateway resource but it should work with the Ingress resource as well.
+// It builds a mapping from BackendServices to Negs.
+func GetGCPBackendFromService(client *kubernetes.Clientset, bkSvc *compute.BackendServicesClient, project string, namespace string, serviceName string) (map[string]string, error) {
+	log := zapr.NewLogger(zap.L())
+	if serviceName == "" {
+		return nil, errors.Errorf("service name cannot be empty")
+	}
+	if namespace == "" {
+		return nil, errors.Errorf("namespace cannot be empty")
+	}
+	negToBackend := make(map[string]string)
+	k8sSvc, err := client.CoreV1().Services(namespace).Get(context.Background(), serviceName, metav1.GetOptions{})
+	if err != nil {
+		return negToBackend, errors.Wrapf(err, "Failed to get service: %v.%v", namespace, serviceName)
+	}
+
+	negStatus, ok := k8sSvc.Annotations[negAnnotation]
+	if !ok {
+		return negToBackend, fmt.Errorf("Service %v.%v is missing annotation %v", namespace, k8sSvc.Name, negAnnotation)
+	}
+
+	neg := NegStatus{}
+	if err := json.Unmarshal([]byte(negStatus), &neg); err != nil {
+		return negToBackend, errors.Wrapf(err, "Could not unmarshal %v to NegStatus", negStatus)
+	}
+
+	for _, negName := range neg.NetworkEndpointGroups {
+		negToBackend[negName] = ""
+	}
+
+	bSvc, err := compute.NewBackendServicesRESTClient(context.Background())
+	defer bSvc.Close()
+
+	if err != nil {
+		return negToBackend, errors.Wrapf(err, "Failed to create backend service client")
+	}
+
+	req := &computepb.ListBackendServicesRequest{
+		Project: project,
+	}
+
+	iter := bSvc.List(context.Background(), req)
+
+	for svc, listErr := iter.Next(); listErr != iterator.Done; svc, listErr = iter.Next() {
+		if listErr != nil {
+			return negToBackend, listErr
+		}
+
+		log.Info("Found backend service", "name", *svc.Name, "num_backends", len(svc.Backends))
+
+		for _, b := range svc.Backends {
+			u, err := url.Parse(*b.Group)
+			if err != nil {
+				return negToBackend, errors.Wrapf(err, "Failed to parse backend group url %v", *b.Group)
+			}
+			segments := strings.Split(u.Path, "/")
+			if segments[len(segments)-2] != "networkEndpointGroups" {
+				continue
+			}
+
+			negName := segments[len(segments)-1]
+			if v, ok := negToBackend[negName]; ok {
+				if v != "" {
+					return negToBackend, fmt.Errorf("Found multiple backends for neg %v", negName)
+				}
+				negToBackend[negName] = *svc.Name
+			}
+		}
+	}
+
+	return negToBackend, nil
+}
+
 // GetGCPBackendFromIngress determines the GCP backend associated with the given K8s service.
 // The backends are stored as annotations on the K8s ingress. An ingress can have multiple backends but these
 // should be named off of the service.
 func GetGCPBackendFromIngress(ingress *v1.Ingress, namespace string, serviceName string) (string, error) {
-
 	backendsJSON, ok := ingress.Annotations[backendsAnnotation]
 	if !ok {
 		return "", fmt.Errorf("Ingress %v.%v is missing annotation %v", namespace, ingress.Name, backendsAnnotation)

--- a/k8s/flags.go
+++ b/k8s/flags.go
@@ -1,0 +1,39 @@
+package k8s
+
+import (
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+)
+
+type K8SClientFlags struct {
+	Kubeconfig string
+}
+
+func (f *K8SClientFlags) AddFlags(cmd *cobra.Command) {
+	kubeconfig := ""
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = filepath.Join(home, ".kube", "config")
+	}
+
+	cmd.Flags().StringVarP(&f.Kubeconfig, "kubeconfig", "", kubeconfig, "The kubeconfig file to use")
+}
+
+func (f *K8SClientFlags) NewClient() (*kubernetes.Clientset, error) {
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", f.Kubeconfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to build config from file %v", f.Kubeconfig)
+	}
+
+	// create the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create clientset")
+	}
+	return clientset, nil
+}


### PR DESCRIPTION
* We want to be able to set the IAP IAM policy in cases where the new Gateway resource is used instead of an ingress

* We identify the associated backend by

  * Identifing the neg(s) associated with a K8s service by looking at its annotations
  * Looping through GCP backend services to find the backend service associated with that neg

  * I believe this approach should work with ingresses as well.