### PR TITLE
Move the files package from the hydros repository to the monogo repository

### DIFF
--- a/files/const.go
+++ b/files/const.go
@@ -1,0 +1,8 @@
+package files
+
+const (
+	// GCSScheme is the scheme for GCS
+	GCSScheme = "gs"
+	// FileScheme is the scheme for local files
+	FileScheme = "file"
+)

--- a/files/factory.go
+++ b/files/factory.go
@@ -1,0 +1,41 @@
+package files
+
+import (
+	"context"
+	"net/url"
+
+	"cloud.google.com/go/storage"
+	"github.com/jlewi/monogo/gcp/gcs"
+	"github.com/pkg/errors"
+)
+
+// Factory returns the correct filehelper based on a files scheme
+type Factory struct{}
+
+func (f *Factory) Get(uri string) (FileHelper, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to parse URI %v", uri)
+	}
+
+	switch u.Scheme {
+	case "":
+		return &LocalFileHelper{}, nil
+	case GCSScheme:
+		ctx := context.Background()
+		client, err := storage.NewClient(ctx)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to create GCS storage client")
+		}
+		return &gcs.GcsHelper{
+			Ctx:    ctx,
+			Client: client,
+		}, nil
+	case FileScheme:
+		return &LocalFileHelper{}, nil
+	case SecretManagerScheme:
+		return &GCPSecretManager{}, nil
+	default:
+		return nil, errors.Errorf("Scheme %v is not supported", u.Scheme)
+	}
+}

--- a/files/interface.go
+++ b/files/interface.go
@@ -1,0 +1,15 @@
+package files
+
+import (
+	"io"
+)
+
+// TODO(jlewi): We should implement a UnionFileHelper that will delegate to the GcsFileHelper or LocalFileHelper
+
+// FileHelper is an interface intended to transparently handle working with GCS, local files, and other filesystems
+// e.g. GCP Secret manager.
+type FileHelper interface {
+	Exists(path string) (bool, error)
+	NewReader(path string) (io.Reader, error)
+	NewWriter(path string) (io.Writer, error)
+}

--- a/files/local.go
+++ b/files/local.go
@@ -1,0 +1,54 @@
+package files
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type LocalFileHelper struct{}
+
+// NewReader creates a new Reader for local file.
+func (h *LocalFileHelper) NewReader(uri string) (io.Reader, error) {
+	schemePrefix := FileScheme + "://"
+	if strings.HasPrefix(uri, schemePrefix) {
+		uri = uri[len(schemePrefix):]
+	}
+	reader, err := os.Open(uri)
+
+	if err != nil {
+		return nil, errors.WithStack(errors.Wrapf(err, "Could not read: %v", uri))
+	}
+
+	return reader, nil
+}
+
+// NewWriter creates a new Writer for the local file.
+//
+// TODO(jlewi): Can we add options to control filemode?
+func (h *LocalFileHelper) NewWriter(uri string) (io.Writer, error) {
+	_, err := os.Stat(uri)
+
+	if err == nil || !os.IsNotExist(err) {
+		return nil, errors.WithStack(errors.Errorf("Can't write %v; It already exists", uri))
+	}
+
+	writer, err := os.Create(uri)
+
+	if err != nil {
+		return nil, errors.WithStack(errors.Wrapf(err, "Could not write: %v", uri))
+	}
+
+	return writer, nil
+}
+
+// Exists checks whether the file exists.
+func (h *LocalFileHelper) Exists(uri string) (bool, error) {
+	_, err := os.Stat(uri)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, nil
+}

--- a/files/local.go
+++ b/files/local.go
@@ -13,9 +13,7 @@ type LocalFileHelper struct{}
 // NewReader creates a new Reader for local file.
 func (h *LocalFileHelper) NewReader(uri string) (io.Reader, error) {
 	schemePrefix := FileScheme + "://"
-	if strings.HasPrefix(uri, schemePrefix) {
-		uri = uri[len(schemePrefix):]
-	}
+	strings.TrimPrefix(uri, schemePrefix)
 	reader, err := os.Open(uri)
 
 	if err != nil {

--- a/files/local.go
+++ b/files/local.go
@@ -13,7 +13,7 @@ type LocalFileHelper struct{}
 // NewReader creates a new Reader for local file.
 func (h *LocalFileHelper) NewReader(uri string) (io.Reader, error) {
 	schemePrefix := FileScheme + "://"
-	strings.TrimPrefix(uri, schemePrefix)
+	uri = strings.TrimPrefix(uri, schemePrefix)
 	reader, err := os.Open(uri)
 
 	if err != nil {

--- a/files/secretmanager.go
+++ b/files/secretmanager.go
@@ -1,0 +1,95 @@
+package files
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/url"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/go-logr/zapr"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// SecretManagerScheme URI scheme for gcp secrets. These need to be lowercase.
+	SecretManagerScheme = "gcpsecretmanager"
+)
+
+// GCPSecretManager implements the interface but for GCP secrets
+// URIs should look like gcpsecretmanager:///projects/${project}/secrets/${secret}/versions/${version}
+type GCPSecretManager struct {
+	Client *secretmanager.Client
+}
+
+// NewReader creates a new Reader for local file.
+func (h *GCPSecretManager) NewReader(uri string) (io.Reader, error) {
+	log := zapr.NewLogger(zap.L())
+
+	if h.Client == nil {
+		log.Info("No client set attempting to create default client")
+		client, err := secretmanager.NewClient(context.Background())
+
+		if err != nil {
+			return nil, err
+		}
+		h.Client = client
+	}
+
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Couldn't parse URI %v", uri)
+	}
+	if u.Scheme != SecretManagerScheme {
+		return nil, errors.Wrapf(err, "URI %v doesn't have scheme %v", uri, u.Scheme)
+	}
+
+	secret := u.Path
+	if u.Host == "projects" {
+		secret = u.Host + u.Path
+	}
+	if secret[0:1] == "/" {
+		secret = secret[1:]
+	}
+
+	accessRequest := &secretmanagerpb.AccessSecretVersionRequest{
+		Name: secret,
+	}
+
+	ctx := context.Background()
+
+	// Call the API.
+	result, err := h.Client.AccessSecretVersion(ctx, accessRequest)
+	if err != nil {
+		status, ok := status.FromError(err)
+
+		if ok {
+			if status.Code() == codes.NotFound {
+				log.Info("Secret doesn't exist", "secret", secret)
+				return nil, errors.Errorf("secret %v doesn't exist", secret)
+			}
+
+			if status.Code() == codes.FailedPrecondition {
+				log.Info("here was a problem trying to access the latest version of secret", "secret", secret, "status_message", status.Message())
+				return nil, errors.Errorf("There was a problem trying to access the latest version of secret %v", secret)
+			}
+		}
+		return nil, errors.Wrapf(err, "failed to access secret %v", secret)
+	}
+
+	return bytes.NewReader(result.Payload.Data), nil
+}
+
+// NewWriter creates a new Writer
+func (h *GCPSecretManager) NewWriter(uri string) (io.Writer, error) {
+	return nil, errors.New("Exists isn't implemented for GCPSecretManager")
+}
+
+// Exists checks whether the file exists.
+func (h *GCPSecretManager) Exists(uri string) (bool, error) {
+	return false, errors.New("Exists isn't implemented for GCPSecretManager")
+}

--- a/files/sugar.go
+++ b/files/sugar.go
@@ -1,0 +1,24 @@
+package files
+
+import (
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// Read reads the given URI
+func Read(uri string) ([]byte, error) {
+	f := &Factory{}
+	h, err := f.Get(uri)
+	if err != nil {
+		return nil, err
+	}
+	r, err := h.NewReader(uri)
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return nil, errors.Errorf("no reader was returned for %v", uri)
+	}
+	return io.ReadAll(r)
+}


### PR DESCRIPTION
Copied at commit https://github.com/jlewi/hydros/tree/751cd2b5f0c7671f4e178c75292c55a9d827ecee/pkg/files

This is reusable code.
We'd like to be able to import without potentially pulling in other dependencies that hydros has such as K8s.