### PR TITLE
Fix panic in ListOfErrors if final is null.

### DIFF
--- a/helpers/errors.go
+++ b/helpers/errors.go
@@ -68,14 +68,19 @@ type ListOfErrors struct {
 
 // Error returns a single error wrapping all the errors.
 func (l *ListOfErrors) Error() string {
-	m := l.Final.Error() + "; Causes: "
+	m := ""
+	if l.Final != nil {
+		m += l.Final.Error() + "; Causes: "
+	} else {
+		m += "List of Errors: "
+	}
 
-	c := []string{}
+	c := make([]string, 0, len(l.Causes))
 	for _, i := range l.Causes {
 		c = append(c, i.Error())
 	}
 
-	m = m + strings.Join(c, ",")
+	m = m + strings.Join(c, ", ")
 	return m
 }
 

--- a/helpers/errors_test.go
+++ b/helpers/errors_test.go
@@ -53,3 +53,43 @@ func Test_IsTypeError(t *testing.T) {
 		})
 	}
 }
+
+func Test_ListOfErrors(t *testing.T) {
+	type testCase struct {
+		name     string
+		input    ListOfErrors
+		expected string
+	}
+
+	cases := []testCase{
+		{
+			name: "basic",
+			input: ListOfErrors{
+				Final: errors.New("final"),
+				Causes: []error{
+					errors.New("cause 1"),
+					errors.New("cause 2"),
+				},
+			},
+			expected: "final; Causes: cause 1, cause 2",
+		},
+		{
+			name: "no-final",
+			input: ListOfErrors{
+				Causes: []error{
+					errors.New("cause 1"),
+					errors.New("cause 2"),
+				},
+			},
+			expected: "List of Errors: cause 1, cause 2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.input.Error()
+			if got != tc.expected {
+				t.Errorf("expected %v; got %v", tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Allow for Final to not be null.

* This was causing us to panic when trying to compute the error string.