### PR TITLE
FileHelper.NewWriter should truncate file if it already exists

### DIFF
--- a/files/interface.go
+++ b/files/interface.go
@@ -11,6 +11,9 @@ import (
 type FileHelper interface {
 	Exists(path string) (bool, error)
 	NewReader(path string) (io.Reader, error)
+	// NewWriter creates a new writer.
+	// If the path already exists the file is truncated.
+	// Caller should call exists to test if it already exists.
 	// TODO(jlewi): Should the return type be io.WriteCloser?
 	NewWriter(path string) (io.Writer, error)
 }

--- a/files/local.go
+++ b/files/local.go
@@ -26,14 +26,11 @@ func (h *LocalFileHelper) NewReader(uri string) (io.Reader, error) {
 
 // NewWriter creates a new Writer for the local file.
 //
-// TODO(jlewi): Can we add options to control filemode?
+// N.B. Prior to 2024/08/26 this function would return an error if the file already existed. This behavior was changed
+// so that the file is truncated if it already exists. If the caller doesn't want to overwrite it, they should
+// use exists to check if the file exists before calling this function. This change was made because we want to
+// support truncation.
 func (h *LocalFileHelper) NewWriter(uri string) (io.Writer, error) {
-	_, err := os.Stat(uri)
-
-	if err == nil || !os.IsNotExist(err) {
-		return nil, errors.WithStack(errors.Errorf("Can't write %v; It already exists", uri))
-	}
-
 	writer, err := os.Create(uri)
 
 	if err != nil {


### PR DESCRIPTION
* Without this change there is no way to support overwriting and truncating objects.

* With this change we can support not overwriting files by making it the caller's responsibility to call exists first if they don't want to overwrite this function.

* FileHelper.NewWriter function was added recently in order to support foyle. (It was moved over from hydros).

* There is one instance in Foyle using NewWriter and the inability to truncate the file is causing a bug.

 https://github.com/jlewi/foyle/issues/205