### PR TITLE
LocalFileHelper.NewWriter should create directories if necessary

### DIFF
--- a/files/local.go
+++ b/files/local.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jlewi/monogo/helpers"
+
 	"github.com/pkg/errors"
 )
 
@@ -31,6 +33,12 @@ func (h *LocalFileHelper) NewReader(uri string) (io.Reader, error) {
 // use exists to check if the file exists before calling this function. This change was made because we want to
 // support truncation.
 func (h *LocalFileHelper) NewWriter(uri string) (io.Writer, error) {
+	dir := filepath.Dir(uri)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, helpers.UserGroupAllPerm); err != nil {
+			return nil, errors.WithStack(errors.Wrapf(err, "Could not create directory: %v", dir))
+		}
+	}
 	writer, err := os.Create(uri)
 
 	if err != nil {

--- a/files/local_test.go
+++ b/files/local_test.go
@@ -1,0 +1,60 @@
+package files
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_LocalNewWriter(t *testing.T) {
+	tDir, err := os.MkdirTemp("", "testLocalNewWriter")
+	if err != nil {
+		t.Fatalf("Error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tDir)
+
+	type testCase struct {
+		name  string
+		input string
+	}
+
+	cases := []testCase{
+		{
+			// Ensure directory is created if it doesn't already exist
+			name:  "basic",
+			input: filepath.Join(tDir, "test.txt"),
+		},
+		{
+			// Ensure directory is created if it doesn't already exist
+			name:  "createdir",
+			input: filepath.Join(tDir, "newDir/test.txt"),
+		},
+	}
+
+	h := &LocalFileHelper{}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			w, err := h.NewWriter(c.input)
+			if err != nil {
+				t.Fatalf("NewWriter() error: %v", err)
+			}
+
+			if _, err := w.Write([]byte("test")); err != nil {
+				t.Fatalf("Write() error: %v", err)
+			}
+
+			closer, ok := w.(io.Closer)
+			if !ok {
+				t.Fatalf("Writer is not a Closer")
+			}
+			if err := closer.Close(); err != nil {
+				t.Fatalf("Close() error: %v", err)
+			}
+
+			if _, err := os.Stat(c.input); err != nil {
+				t.Errorf("Stat() error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* If the directories don't exist the NewWriter should create it.
* I don't think it makes sense to make it the callers responsibility because not all filesystems (e.g. object storage) have a notion of directories so its better to make it the FileHelper's responsibility.